### PR TITLE
feat: Bump redash to 10.1

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,3 +1,3 @@
-FROM redash/redash:8.0.0.b32245
+FROM redash/redash:10.1.0.b50633
 WORKDIR /app
 CMD /usr/local/bin/gunicorn -b 0.0.0.0:$PORT --name redash -w${REDASH_WEB_WORKERS:-1} redash.wsgi:app

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,4 +1,4 @@
-FROM redash/redash:8.0.0.b32245
+FROM redash/redash:10.1.0.b50633
 
 ENV WORKERS_COUNT=${WORKERS_COUNT:-1}
 ENV QUEUES=${QUEUES:-celery}


### PR DESCRIPTION
## このPRで実現したいこと

redash.ecbooster.jp をRedash 10.1でホストする。

## 動作確認手順

Review Appでダッシュボードが表示されればよし（最低限の環境変数しか入れていないので、クエリは表示できない）
https://redash-ecbooster-redash-clnnqq.herokuapp.com/dashboards
