### PR TITLE
Fix-cmd

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -5,4 +5,4 @@ ENV QUEUES=${QUEUES:-"periodic emails default"}
 
 WORKDIR /app
 
-CMD worker
+CMD /app/bin/docker-entrypoint worker


### PR DESCRIPTION
#2 では親イメージ `redash/redash` の ENTRYPOINT スクリプトを使うつもりが使えていなかったので、エントリーポイントへのパスをフルパスで `CMD` に書く。