### PR TITLE
Workerにデフォルトのキューを参照させる

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,7 +1,6 @@
 FROM redash/redash:10.1.0.b50633
 
 ENV WORKERS_COUNT=${WORKERS_COUNT:-1}
-ENV QUEUES=${QUEUES:-"periodic emails default"}
 
 WORKDIR /app
 


### PR DESCRIPTION
## このPRで実現したいこと

worker dynoでスケジュール実行のクエリも実行できるようにしたい。
worker の環境変数 `QUEUES` に キューの名前を指定すると、RQのworkerで参照するキューの名前になる。

[Release v10.0.0 · getredash/redash](https://github.com/getredash/redash/releases/tag/v10.0.0) によれば、 `QUEUES` には `"periodic emails default"` を指定するように書かれているが、これらのキューにはスケジュール実行のクエリは含まれない。

`QUEUES` を指定しないことで、スケジュール実行を含むデフォルトのキューをworkerに参照させる。
https://github.com/getredash/redash/blob/d8d7c78992e44a4b6d7fdd4c39ccc1c35cd8c7a9/redash/worker.py#L20-L22